### PR TITLE
Fix: app initialisation error

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -167,7 +167,7 @@ class WindowTitleBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (Platform.isMacOS) {
-      return MenuBar(
+      return CustomMenuBar(
         child: MediaQuery.fromWindow(
           child: Builder(
             builder: (context) {

--- a/lib/app/features/adb/adb_service.dart
+++ b/lib/app/features/adb/adb_service.dart
@@ -4,6 +4,7 @@ import 'dart:io' as io;
 import 'dart:io';
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart' as p;
 
 import '../../utils/utils.dart';
@@ -145,7 +146,7 @@ Map<String, String>? _unixEnvironmentMap;
 
 Future<Map<String, String>?> _loadUnixEnvironment() async {
   final supportDir = await p.getApplicationSupportDirectory();
-  final tempFile = File('${supportDir.absolute.path}/env.sh');
+  final tempFile = File(join(supportDir.absolute.path, 'env.sh'));
   logInfo('Created temp sh file at ${tempFile.absolute.path}');
 
   tempFile.createSync(recursive: true);
@@ -154,16 +155,16 @@ Future<Map<String, String>?> _loadUnixEnvironment() async {
   await Future.delayed(const Duration(milliseconds: 300));
 
   // execution permissions (no need to get result).
-  final chmodResult =
-      // io.Process.runSync('chmod', ['777', '"${tempFile.absolute.path}"']);
-      io.Process.runSync('/bin/sh', ['-c', 'chmod +x "${tempFile.absolute.path}"']);
+  final chmodResult = io.Process.runSync('chmod', ['u+x', 'env.sh'],
+      workingDirectory: supportDir.absolute.path);
   LogFile.instance.dispath(
-      "Permission result (${chmodResult.exitCode}) - out= ${chmodResult.stdout} - err=${chmodResult.stderr}");
+      "Permission result (${chmodResult.exitCode}) - out=${chmodResult.stdout} - err=${chmodResult.stderr}");
 
   final result = Process.runSync(
-    '/bin/sh',
-    ['-c', '"${tempFile.absolute.path}"'],
+    'bash',
+    ['-c', './env.sh'],
     runInShell: true,
+    workingDirectory: supportDir.absolute.path,
   );
   final envMap = <String, String>{};
   var stdOut = result.stdout.toString().trim();

--- a/lib/app/features/menubar/menubar_view.dart
+++ b/lib/app/features/menubar/menubar_view.dart
@@ -7,10 +7,10 @@ import 'package:path_provider/path_provider.dart';
 import '../../utils/utils.dart';
 import '../features.dart';
 
-class MenuBar extends StatelessWidget {
+class CustomMenuBar extends StatelessWidget {
   final Widget child;
 
-  const MenuBar({super.key, required this.child});
+  const CustomMenuBar({super.key, required this.child});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/utils/constants.dart
+++ b/lib/app/utils/constants.dart
@@ -74,9 +74,9 @@ String exceptionToString(Object exception) {
     }
   } else {
     if (exception is AppException) {
-      exception = exception.message;
+      message = exception.message;
     } else if (exception is PlatformException) {
-      exception = exception.message ?? exception.code;
+      message = exception.message ?? exception.code;
     } else {
       message = exception.toString();
     }


### PR DESCRIPTION
## NOTE - TODO##

- While on the next commit please use `package:path` to join the path.
- Use `workingDirectory` in the `run`, `runSync`, `start` instead of the whole path.
- Use `pathSaperator` instead of `\`(Windows) and `/` (mac/unix)